### PR TITLE
spec: Revise mnd_headless to clarify xrWaitFrame

### DIFF
--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -2352,7 +2352,7 @@ maintained in the master branch of the Khronos OpenXR GitHub project.
 
     <extension name="XR_MND_headless" number="43" type="instance" supported="openxr">
         <require>
-            <enum value="1" name="XR_MND_headless_SPEC_VERSION"/>
+            <enum value="2" name="XR_MND_headless_SPEC_VERSION"/>
             <enum value="&quot;XR_MND_headless&quot;" name="XR_MND_HEADLESS_EXTENSION_NAME"/>
         </require>
     </extension>

--- a/specification/sources/chapters/extensions/mnd/mnd_headless.adoc
+++ b/specification/sources/chapters/extensions/mnd/mnd_headless.adoc
@@ -1,7 +1,7 @@
 include::../meta/XR_MND_headless.adoc[]
 
 *Last Modified Date*::
-    2019-07-25
+    2019-10-22
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -43,6 +43,12 @@ named entities.
   sessions.
 * In a headless session, flink:xrEnumerateSwapchainFormats must: return
   ename:XR_SUCCESS but enumerate `0` formats.
+* flink:xrWaitFrame must: set slink:XrFrameState::pname:shouldRender to
+  code:XR_FALSE in a headless session.
+  The VISIBLE and FOCUSED states are only used for their input-related
+  semantics, not their rendering-related semantics, and these functions are
+  permitted to allow minimal change between headless and non-headless code
+  if desired.
 
 Because flink:xrWaitFrame is not required, an application using a headless
 session should: sleep periodically to avoid consuming all available system
@@ -69,3 +75,6 @@ resources in a busy-wait loop.
 
 * Revision 1, 2019-07-25 (Ryan Pavlik)
 ** Initial version reflecting Monado prototype.
+* Revision 2, 2019-10-22 (Ryan Pavlik)
+** Clarify that `xrWaitFrame` is permitted and should set `shouldRender` to
+   false.


### PR DESCRIPTION
Modifies our mnd vendor extension for headless to clarify some behavior in a way that makes it more useful.