### PR TITLE
Replace biased terminology with a more neutral term, allowlist.

### DIFF
--- a/specification/scripts/extensionmetadocgenerator.py
+++ b/specification/scripts/extensionmetadocgenerator.py
@@ -576,16 +576,16 @@ class ExtensionMetaDocOutputGenerator(OutputGenerator):
         return attrib
 
     def numbersToWords(self, name):
-        whitelist = ['WIN32', 'INT16', 'D3D1']
+        allowlist = ['WIN32', 'INT16', 'D3D1']
 
-        # temporarily replace whitelist items
-        for i, w in enumerate(whitelist):
+        # temporarily replace allowlist items
+        for i, w in enumerate(allowlist):
             name = re.sub(w, '{' + str(i) + '}', name)
 
         name = re.sub(r'(?<=[A-Z])(\d+)(?![A-Z])', r'_\g<1>', name)
 
-        # undo whitelist substitution
-        for i, w in enumerate(whitelist):
+        # undo allowlist substitution
+        for i, w in enumerate(allowlist):
             name = re.sub('\\{' + str(i) + '}', w, name)
 
         return name

--- a/specification/sources/chapters/input.adoc
+++ b/specification/sources/chapters/input.adoc
@@ -565,10 +565,10 @@ bindings contain paths that do not follow the format defined in
 <<semantic-path-input, Device input subpaths>>, the runtime must: return
 ename:XR_ERROR_PATH_UNSUPPORTED.
 If the interaction profile or input source for any of the suggested bindings
-does not exist in the whitelist defined in
+does not exist in the allowlist defined in
 <<semantic-path-interaction-profiles, Interaction Profile Paths>>, the
 runtime must: return ename:XR_ERROR_PATH_UNSUPPORTED.
-A runtime must: accept every valid binding in the whitelist though it is
+A runtime must: accept every valid binding in the allowlist though it is
 free to ignore any of them.
 
 If the action set for any action referenced in the pname:suggestedBindings


### PR DESCRIPTION
In all cases we could cleanly replace the existing biased term, 'whitelist' with the more neutral and equally descriptive term, 'allowlist'