### PR TITLE
make the runtime requirements of xrGetCurrentInteractionProfile consi…

### DIFF
--- a/specification/sources/chapters/input.adoc
+++ b/specification/sources/chapters/input.adoc
@@ -706,7 +706,8 @@ flink:xrGetCurrentInteractionProfile asks the runtime for the active
 interaction profiles for a top level user path.
 
 The runtime must: return only interaction profiles for which the application
-has provided bindings with flink:xrSuggestInteractionProfileBindings.
+has provided bindings with flink:xrSuggestInteractionProfileBindings or
+dlink:XR_NULL_PATH.
 The runtime may: return interaction profiles that do not represent
 physically present hardware, for example if the runtime is using a known
 interaction profile to bind to hardware that the application is not aware


### PR DESCRIPTION
…stent with those of XrInteractionProfileState

There is information (specifically the possibility of returning `XR_NULL_PATH`) here: https://www.khronos.org/registry/OpenXR/specs/1.0/man/html/XrInteractionProfileState.html which is absent here: https://www.khronos.org/registry/OpenXR/specs/1.0/man/html/xrGetCurrentInteractionProfile.html , despite that it pertains more directly to the function than to the struct.