### PR TITLE
Updated cgenerator to output which struct is extended by another

### DIFF
--- a/specification/scripts/cgenerator.py
+++ b/specification/scripts/cgenerator.py
@@ -341,7 +341,9 @@ class COutputGenerator(OutputGenerator):
             if self.genOpts.genAliasMacro and self.typeMayAlias(typeName):
                 body += ' ' + self.genOpts.aliasMacro
 
-            body += ' ' + typeName + ' {\n'
+            structextends = typeElem.get('structextends')
+            extends_comment = ' // extends ' + structextends if structextends else ''
+            body += ' ' + typeName + ' {' + extends_comment + '\n'
 
             targetLen = self.getMaxCParamTypeLength(typeinfo)
             for member in typeElem.findall('.//member'):


### PR DESCRIPTION
Updated `cgenerator.py` so that the generated headers will show a comment when a struct extends another struct.

I think this will help people understand which structs should be chained when they are browsing `openxr.h` and `openxr_platform.h`.

For example:

```c++
typedef struct XrSpaceVelocity { // extends XrSpaceLocation
    XrStructureType         type;
    void* XR_MAY_ALIAS      next;
    XrSpaceVelocityFlags    velocityFlags;
    XrVector3f              linearVelocity;
    XrVector3f              angularVelocity;
} XrSpaceVelocity;

typedef struct XrEyeGazeSampleTimeEXT { // extends XrSpaceLocation
    XrStructureType       type;
    void* XR_MAY_ALIAS    next;
    XrTime                time;
} XrEyeGazeSampleTimeEXT;

typedef struct XrSystemEyeGazeInteractionPropertiesEXT { // extends XrSystemProperties
    XrStructureType       type;
    void* XR_MAY_ALIAS    next;
    XrBool32              supportsEyeGazeInteraction;
} XrSystemEyeGazeInteractionPropertiesEXT;

typedef struct XrSystemHandTrackingPropertiesEXT { // extends XrSystemProperties
    XrStructureType       type;
    void* XR_MAY_ALIAS    next;
    XrBool32              supportsHandTracking;
} XrSystemHandTrackingPropertiesEXT;

typedef struct XrGraphicsBindingVulkanKHR { // extends XrSessionCreateInfo
    XrStructureType             type;
    const void* XR_MAY_ALIAS    next;
    VkInstance                  instance;
    VkPhysicalDevice            physicalDevice;
    VkDevice                    device;
    uint32_t                    queueFamilyIndex;
    uint32_t                    queueIndex;
} XrGraphicsBindingVulkanKHR;
```