### PR TITLE
Replace '<<mr-reserve-extension-number,example>>' in the extension process with a link to the example used in the style guide

### DIFF
--- a/changes/registry/pr.78.gh.OpenXR-Docs.md
+++ b/changes/registry/pr.78.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+Replace '<<mr-reserve-extension-number,example>>' in the extension process with a link to the example used in the style guide.

--- a/specification/sources/extprocess/extension_process.adoc
+++ b/specification/sources/extprocess/extension_process.adoc
@@ -223,7 +223,7 @@ assignment prior to extension publication:
      `supported="disabled"`.
      The extension number will be reserved only once this merge request is
      accepted.
-     See the <<mr-reserve-extension-number,example>> below.
+     Please refer to link:https://www.khronos.org/registry/OpenXR/specs/1.0/styleguide.html#mr-reserve-extension-number[the example in the style guide].
    * The extension number will be reserved only once this merge request is
      accepted.
    * To accommodate internal development of the specification, the spec


### PR DESCRIPTION
[OpenXR™ Working Group Extension Processes](https://www.khronos.org/registry/OpenXR/specs/1.0/extprocess.html) mentions an example of reserving extension number but it's absent. The example presented in [OpenXR™ Documentation and Extensions: Procedures and Conventions](https://www.khronos.org/registry/OpenXR/specs/1.0/styleguide.html#mr-reserve-extension-number) is added to reduce confusion.