### PR TITLE
Clarify the usage of xrGetGraphicsRequirements

### DIFF
--- a/specification/sources/chapters/session.adoc
+++ b/specification/sources/chapters/session.adoc
@@ -81,10 +81,17 @@ These extensions can be activated during slink:XrInstance create time.
 During slink:XrSession creation the application must: provide information
 about which graphics API it intends to use by adding an XrGraphicsBinding...
 struct of one (and only one) of the enabled graphics API extensions to the
-next chain of slink:XrSessionCreateInfo.
+next chain of slink:XrSessionCreateInfo. The application must: call the 
+`xrGet<*>GraphicsRequirements` type method provided by the chosen graphics API 
+extension before attempting to create the session (for example
+flink:xrGetD3D11GraphicsRequirementsKHR, flink:xrGetD3D12GraphicsRequirementsKHR,
+flink:xrGetOpenGLGraphicsRequirementsKHR, xrGetOpenGLESGraphicsRequirementsKHR,
+flink:xrGetVulkanGraphicsRequirementsKHR).
+
 Unless specified differently in the graphics API extension, the application
-is responsible for creating a valid graphics device binding (for details
-refer to the extension specification of the graphics API).
+is responsible for creating a valid graphics device binding based on the requirements
+returned by `xrGet<*>GraphicsRequirements` methods (for details refer to the extension
+specification of the graphics API).
 
 [open,refpage='xrCreateSession',desc='Creates an XrSession',type='protos',xrefs='xrDestroySession xrBeginSession xrEndSession XrSessionCreateInfo XrSessionCreateFlags XrExtensionProperties']
 --
@@ -107,6 +114,12 @@ This session is created in the ename:XR_SESSION_STATE_IDLE state, and a
 corresponding slink:XrEventDataSessionStateChanged event to the
 ename:XR_SESSION_STATE_IDLE state must: be generated as the first such event
 for the new session.
+
+The runtime must: return XR_ERROR_GRAPHICS_REQUIREMENTS_CALL_MISSING 
+(XR_ERROR_VALIDATION_FAILURE may be returned due to legacy behavior) on calls
+to flink:xrCreateSession if a function of the style 
+`xrGet<*>GraphicsRequirementsKHR` has not been called for the same instance and
+systemId.
 
 include::../../generated/validity/protos/xrCreateSession.txt[]
 --


### PR DESCRIPTION
I thought it would be more useful to propose a specific wording than just creating an issue.
I have tried to write in the right syntax but I haven't tested the build.

There was no reference to the requirement to call the `xrGet<*>GraphicsRequirements` methods from the graphics API extension in the xrCreateSession method definition.

The fact that the names of the functions don't have a common prefix but the API name is added in the middle instead made it hard to find them just searching by the `xrGetGraphicsRequirements` method referenced in the XR_ERROR_GRAPHICS_REQUIREMENTS_CALL_MISSING error code description.

