### PR TITLE
Fix reflow script

### DIFF
--- a/changes/specification/pr.97.gh.OpenXR-Docs.md
+++ b/changes/specification/pr.97.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+Scripts: Fix reflow script error message and make sure it creates the necessary output directory.

--- a/specification/scripts/reflow.py
+++ b/specification/scripts/reflow.py
@@ -33,6 +33,7 @@ import re
 import sys
 from reflib import loadFile, logDiag, logWarn, setLogFile
 from reflow_count import startVUID
+from pathlib import Path
 
 from xrconventions import OpenXRConventions as APIConventions
 conventions = APIConventions()
@@ -555,7 +556,14 @@ def reflowFile(filename, args):
     if args.overwrite:
         outFilename = filename
     else:
-        outFilename = args.outDir + '/' + os.path.basename(filename) + args.suffix
+        outDir = Path(args.outDir).resolve()
+        # TOCTOU-safe directory creation
+        try:
+            outDir.mkdir()
+        except FileExistsError:
+            pass
+
+        outFilename = str(outDir / (os.path.basename(filename) + args.suffix))
 
     try:
         fp = open(outFilename, 'w', encoding='utf8', newline=newline_string)

--- a/specification/scripts/reflow.py
+++ b/specification/scripts/reflow.py
@@ -560,7 +560,7 @@ def reflowFile(filename, args):
     try:
         fp = open(outFilename, 'w', encoding='utf8', newline=newline_string)
     except:
-        logWarn('Cannot open output file', filename, ':', sys.exc_info()[0])
+        logWarn('Cannot open output file', outFilename, ':', sys.exc_info()[0])
         return
 
     state = ReflowState(filename,


### PR DESCRIPTION
The error message was incorrect, and we defaulted to not overwriting and outputting in a different folder, but we never created it.

- reflow: Fix filename in error message
- reflow: If not overwriting, make sure the out directory exists.
