### PR TITLE
Fix inconsistent specified semantics for array getters

### DIFF
--- a/changes/specification/pr.104.gh.OpenXR-Docs.md
+++ b/changes/specification/pr.104.gh.OpenXR-Docs.md
@@ -1,0 +1,6 @@
+---
+- issue.94.gh.OpenXR-Docs
+- issue.1599.gl
+- issue.1612.gl
+---
+- Clarify inconsistent specified semantics for array getters, resolving ambiguity in favor of the fundamentals section on buffer size parameters.

--- a/specification/sources/chapters/extensions/fb/fb_color_space.adoc
+++ b/specification/sources/chapters/extensions/fb/fb_color_space.adoc
@@ -158,7 +158,8 @@ include::{INCS-VAR}/api/protos/xrEnumerateColorSpacesFB.txt[]
   array, or 0 to retrieve the required capacity.
 * pname:colorSpaceCountOutput is a pointer to the count of
   elink:XrColorSpaceFB pname:colorSpaces written, or a pointer to the
-  required capacity in the case that pname:colorSpaceCapacityInput is `0`.
+  required capacity in the case that pname:colorSpaceCapacityInput is
+  insufficient.
 * pname:colorSpaces is a pointer to an array of elink:XrColorSpaceFB color
   spaces, but can: be code:NULL if pname:colorSpaceCapacityInput is `0`.
 * See <<buffer-size-parameters, Buffer Size Parameters>> chapter for a

--- a/specification/sources/chapters/extensions/fb/fb_display_refresh_rate.adoc
+++ b/specification/sources/chapters/extensions/fb/fb_display_refresh_rate.adoc
@@ -92,7 +92,8 @@ include::{INCS-VAR}/api/protos/xrEnumerateDisplayRefreshRatesFB.txt[]
   pname:displayRefreshRates, or 0 to retrieve the required capacity.
 * pname:displayRefreshRateCountOutput is a pointer to the count of
   code:float pname:displayRefreshRates written, or a pointer to the required
-  capacity in the case that pname:displayRefreshRateCapacityInput is `0`.
+  capacity in the case that pname:displayRefreshRateCapacityInput is
+  insufficient.
 * pname:displayRefreshRates is a pointer to an array of code:float display
   refresh rates, but can: be code:NULL if
   pname:displayRefreshRateCapacityInput is `0`.

--- a/specification/sources/chapters/extensions/fb/fb_hand_tracking_mesh.adoc
+++ b/specification/sources/chapters/extensions/fb/fb_hand_tracking_mesh.adoc
@@ -104,7 +104,7 @@ include::{INCS-VAR}/api/structs/XrHandTrackingMeshFB.txt[]
 * pname:indexCountOutput is filled in by the runtime with the count of index
   data elements written, or the required capacity in the case that any of
   pname:jointCapacityInput, pname:vertexCapacityInput, or
-  pname:indexCapacityInput is `0`.
+  pname:indexCapacityInput is insufficient.
 * pname:indices is an array of triangle indices.
 * See the <<buffer-size-parameters> section for a detailed description of
   retrieving the required array sizes in the "struct form" as used here.

--- a/specification/sources/chapters/extensions/htcx/htcx_vive_tracker_interaction.adoc
+++ b/specification/sources/chapters/extensions/htcx/htcx_vive_tracker_interaction.adoc
@@ -193,7 +193,8 @@ include::{INCS-VAR}/api/protos/xrEnumerateViveTrackerPathsHTCX.txt[]
   `0` to retrieve the required capacity.
 * pname:pathsCountOutput is a pointer to the count of
   slink:XrViveTrackerPathsHTCX pname:viveTrackerPaths written, or a pointer
-  to the required capacity in the case that pname:pathsCapacityInput is `0`.
+  to the required capacity in the case that pname:pathsCapacityInput is
+  insufficient.
 * pname:viveTrackerPaths is a pointer to an array of
   slink:XrViveTrackerPathsHTCX VIVE tracker paths, but can: be code:NULL if
   pname:pathsCapacityInput is `0`.

--- a/specification/sources/chapters/extensions/khr/khr_visibility_mask.adoc
+++ b/specification/sources/chapters/extensions/khr/khr_visibility_mask.adoc
@@ -98,7 +98,7 @@ include::../../../../generated/api/structs/XrVisibilityMaskKHR.txt[]
   `0` to indicate a request to retrieve the required capacity.
 * pname:vertexCountOutput is filled in by the runtime with the count of
   vertices written or the required capacity in the case that
-  pname:vertexCapacityInput or pname:indexCapacityInput is `0`.
+  pname:vertexCapacityInput or pname:indexCapacityInput is insufficient.
 * pname:vertices is an array of vertices filled in by the runtime that
   specifies mask coordinates in the z=-1 plane of the rendered view--i.e.
   one meter in front of the view.
@@ -110,7 +110,7 @@ include::../../../../generated/api/structs/XrVisibilityMaskKHR.txt[]
   `0` to indicate a request to retrieve the required capacity.
 * pname:indexCountOutput is filled in by the runtime with the count of
   indices written or the required capacity in the case that
-  pname:vertexCapacityInput or pname:indexCapacityInput is `0`.
+  pname:vertexCapacityInput or pname:indexCapacityInput is insufficient.
 * pname:indices is an array of indices filled in by the runtime, specifying
   the indices of the mask geometry in the pname:vertices array.
 ****

--- a/specification/sources/chapters/extensions/khr/khr_vulkan_enable.adoc
+++ b/specification/sources/chapters/extensions/khr/khr_vulkan_enable.adoc
@@ -369,7 +369,7 @@ include::../../../../generated/api/protos/xrGetVulkanInstanceExtensionsKHR.txt[]
   indicate a request to retrieve the required capacity.
 * pname:bufferCountOutput is a pointer to the count of characters written
   (including terminating `\0`), or a pointer to the required capacity in the
-  case that pname:bufferCapacityInput is 0.
+  case that pname:bufferCapacityInput is insufficient.
 * pname:buffer is a pointer to an array of characters, but can: be code:NULL
   if pname:bufferCapacityInput is 0.
   The format of the output is a single space (ASCII `0x20`) delimited string
@@ -395,7 +395,7 @@ include::../../../../generated/api/protos/xrGetVulkanDeviceExtensionsKHR.txt[]
   indicate a request to retrieve the required capacity.
 * pname:bufferCountOutput is a pointer to the count of characters written
   (including terminating `\0`), or a pointer to the required capacity in the
-  case that pname:bufferCapacityInput is 0.
+  case that pname:bufferCapacityInput is insufficient.
 * pname:buffer is a pointer to an array of characters, but can: be code:NULL
   if pname:bufferCapacityInput is 0.
   The format of the output is a single space (ASCII `0x20`) delimited string

--- a/specification/sources/chapters/extensions/msft/msft_composition_layer_reprojection.adoc
+++ b/specification/sources/chapters/extensions/msft/msft_composition_layer_reprojection.adoc
@@ -42,7 +42,8 @@ include::../../../../generated/api/protos/xrEnumerateReprojectionModesMSFT.txt[]
 * pname:modeCapacityInput is the capacity of the array, or 0 to indicate a
   request to retrieve the required capacity.
 * pname:modeCountOutput is a pointer to the count of the array, or a pointer
-  to the required capacity in the case that pname:modeCapacityInput is 0.
+  to the required capacity in the case that pname:modeCapacityInput is
+  insufficient.
 * pname:modes is a pointer to an application-allocated array that will be
   filled with the elink:XrReprojectionModeMSFT values that are supported by
   the runtime.

--- a/specification/sources/chapters/extensions/msft/msft_controller_model.adoc
+++ b/specification/sources/chapters/extensions/msft/msft_controller_model.adoc
@@ -120,7 +120,7 @@ include::../../../../generated/api/protos/xrLoadControllerModelMSFT.txt[]
   to indicate a request to retrieve the required capacity.
 * pname:bufferCountOutput filled in by the runtime with the count of
   elements in pname:buffer array, or returns the required capacity in the
-  case that pname:bufferCapacityInput is 0.
+  case that pname:bufferCapacityInput is insufficient.
 * pname:buffer is a pointer to an application-allocated array of the model
   for the device that will be filled with the code:uint8_t values by the
   runtime.
@@ -205,7 +205,7 @@ include::../../../../generated/api/structs/XrControllerModelPropertiesMSFT.txt[]
   or 0 to indicate a request to retrieve the required capacity.
 * pname:nodeCountOutput filled in by the runtime with the count of elements
   in pname:nodeProperties array, or returns the required capacity in the
-  case that pname:nodeCapacityInput is 0.
+  case that pname:nodeCapacityInput is insufficient.
 * pname:nodeProperties is a pointer to an application-allocated array that
   will be filled with the slink:XrControllerModelNodePropertiesMSFT values.
   It can: be code:NULL if pname:nodeCapacityInput is 0.
@@ -299,7 +299,7 @@ include::../../../../generated/api/structs/XrControllerModelStateMSFT.txt[]
   0 to indicate a request to retrieve the required capacity.
 * pname:nodeCountOutput filled in by the runtime with the count of elements
   in pname:nodeStates array, or returns the required capacity in the case
-  that pname:nodeCapacityInput is 0.
+  that pname:nodeCapacityInput is insufficient.
 * pname:nodeStates is a pointer to an application-allocated array that will
   be filled with the slink:XrControllerModelNodeStateMSFT values.
   It can: be code:NULL if pname:sourceCapacityInput is 0.

--- a/specification/sources/chapters/extensions/msft/msft_scene_understanding.adoc
+++ b/specification/sources/chapters/extensions/msft/msft_scene_understanding.adoc
@@ -501,7 +501,7 @@ include::../../../../generated/api/protos/xrEnumerateSceneComputeFeaturesMSFT.tx
   a request to retrieve the required capacity.
 * pname:featureCountOutput is a pointer to the count of scene compute
   features, or a pointer to the required capacity in the case that
-  pname:featureCapacityInput is 0.
+  pname:featureCapacityInput is insufficient.
 * pname:features is an array of elink:XrSceneComputeFeatureMSFT.
 ****
 
@@ -826,7 +826,7 @@ include::../../../../generated/api/structs/XrSceneComponentsMSFT.txt[]
   indicate a request to retrieve the required capacity.
 * pname:componentCountOutput is a pointer to the count of components, or a
   pointer to the required capacity in the case that
-  pname:componentCapacityInput is 0.
+  pname:componentCapacityInput is insufficient.
 * pname:components is an array of slink:XrSceneComponentMSFT.
 * See <<buffer-size-parameters, Buffer Size Parameters>> chapter for a
   detailed description of retrieving the required pname:components size.
@@ -1329,7 +1329,7 @@ include::../../../../generated/api/structs/XrSceneMeshVertexBufferMSFT.txt[]
   request to retrieve the required capacity.
 * pname:vertexCountOutput is a pointer to the count of vertices, or a
   pointer to the required capacity in the case that
-  pname:vertexCapacityInput is 0.
+  pname:vertexCapacityInput is insufficient.
 * pname:vertices is an array of slink:XrVector3f filled in by the runtime
   returns the position of vertices in the mesh component's space.
 * See <<buffer-size-parameters, Buffer Size Parameters>> chapter for a
@@ -1354,7 +1354,8 @@ include::../../../../generated/api/structs/XrSceneMeshIndicesUint32MSFT.txt[]
 * pname:indexCapacityInput is the capacity of the array, or 0 to indicate a
   request to retrieve the required capacity.
 * pname:indexCountOutput is a pointer to the count of indices, or a pointer
-  to the required capacity in the case that pname:indexCapacityInput is 0.
+  to the required capacity in the case that pname:indexCapacityInput is
+  insufficient.
 * pname:indices is an array of triangle indices filled in by the runtime,
   specifying the indices of the scene mesh buffer in the vertices array.
   The triangle indices must: be returned in counter-clockwise order and
@@ -1381,7 +1382,8 @@ include::../../../../generated/api/structs/XrSceneMeshIndicesUint16MSFT.txt[]
 * pname:indexCapacityInput is the capacity of the array, or 0 to indicate a
   request to retrieve the required capacity.
 * pname:indexCountOutput is a pointer to the count of indices, or a pointer
-  to the required capacity in the case that pname:indexCapacityInput is 0.
+  to the required capacity in the case that pname:indexCapacityInput is
+  insufficient.
 * pname:indices is an array of triangle indices filled in by the runtime,
   specifying the indices of the scene mesh buffer in the vertices array.
   The triangle indices must: be returned in counter-clockwise order and

--- a/specification/sources/chapters/extensions/msft/msft_spatial_anchor_persistence.adoc
+++ b/specification/sources/chapters/extensions/msft/msft_spatial_anchor_persistence.adoc
@@ -178,7 +178,7 @@ include::../../../../generated/api/protos/xrEnumeratePersistedSpatialAnchorNames
   the required capacity.
 * pname:spatialAnchorNamesCountOutput is filled in by the runtime with the
   count of anchor names written or the required capacity in the case that
-  pname:spatialAnchorNamesCapacityInput is `0`.
+  pname:spatialAnchorNamesCapacityInput is insufficient.
 * pname:persistedAnchorNames is a pointer to an array of
   slink:XrSpatialAnchorPersistenceNameMSFT structures, but can: be code:NULL
   if propertyCapacityInput is `0`.

--- a/specification/sources/chapters/input.adoc
+++ b/specification/sources/chapters/input.adoc
@@ -1371,7 +1371,8 @@ include::../../generated/api/protos/xrEnumerateBoundSourcesForAction.txt[]
 * pname:sourceCapacityInput is the capacity of the array, or 0 to indicate a
   request to retrieve the required capacity.
 * pname:sourceCountOutput is a pointer to the count of sources, or a pointer
-  to the required capacity in the case that pname:sourceCapacityInput is 0.
+  to the required capacity in the case that pname:sourceCapacityInput is
+  insufficient.
 * pname:sources is a pointer to an application-allocated array that will be
   filled with the basetype:XrPath values for all sources.
   It can: be code:NULL if pname:sourceCapacityInput is 0.
@@ -1429,7 +1430,7 @@ include::../../generated/api/protos/xrGetInputSourceLocalizedName.txt[]
   a request to retrieve the required capacity.
 * pname:bufferCountOutput is a pointer to the count of name characters
   written (including the terminating `\0`), or a pointer to the required
-  capacity in the case that pname:bufferCapacityInput is 0.
+  capacity in the case that pname:bufferCapacityInput is insufficient.
 * pname:buffer is a pointer to an application-allocated buffer that will be
   filled with the source name.
   It can: be code:NULL if pname:bufferCapacityInput is 0.

--- a/specification/sources/chapters/instance.adoc
+++ b/specification/sources/chapters/instance.adoc
@@ -76,7 +76,7 @@ include::../../generated/api/protos/xrEnumerateApiLayerProperties.txt[]
   to indicate a request to retrieve the required capacity.
 * pname:propertyCountOutput is a pointer to the count of properties written,
   or a pointer to the required capacity in the case that
-  propertyCapacityInput is 0.
+  propertyCapacityInput is insufficient.
 * pname:properties is a pointer to an array of slink:XrApiLayerProperties
   structures, but can: be code:NULL if propertyCapacityInput is 0.
 * See the <<buffer-size-parameters, Buffer Size Parameters>> section for a
@@ -168,7 +168,7 @@ include::../../generated/api/protos/xrEnumerateInstanceExtensionProperties.txt[]
   `0` to indicate a request to retrieve the required capacity.
 * pname:propertyCountOutput is a pointer to the count of properties written,
   or a pointer to the required capacity in the case that
-  pname:propertyCapacityInput is `0`.
+  pname:propertyCapacityInput is insufficient.
 * pname:properties is a pointer to an array of slink:XrExtensionProperties
   structures, but can: be code:NULL if pname:propertyCapacityInput is `0`.
 * See the <<buffer-size-parameters, Buffer Size Parameters>> section for a

--- a/specification/sources/chapters/rendering.adoc
+++ b/specification/sources/chapters/rendering.adoc
@@ -67,7 +67,7 @@ include::../../generated/api/protos/xrEnumerateSwapchainFormats.txt[]
   retrieve the required capacity.
 * pname:formatCountOutput is a pointer to the count of code:uint64_t formats
   written, or a pointer to the required capacity in the case that
-  pname:formatCapacityInput is `0`.
+  pname:formatCapacityInput is insufficient.
 * pname:formats is a pointer to an array of code:int64_t format ids, but
   can: be code:NULL if pname:formatCapacityInput is `0`.
   The format ids are specific to the specified graphics API.
@@ -288,7 +288,7 @@ include::../../generated/api/protos/xrEnumerateSwapchainImages.txt[]
   to indicate a request to retrieve the required capacity.
 * pname:imageCountOutput is a pointer to the count of pname:images written,
   or a pointer to the required capacity in the case that
-  pname:imageCapacityInput is 0.
+  pname:imageCapacityInput is insufficient.
 * pname:images is a pointer to an array of graphics API-specific
   `XrSwapchainImage` structures, all of the same type, based on
   slink:XrSwapchainImageBaseHeader.
@@ -1427,7 +1427,7 @@ include::../../generated/api/protos/xrEnumerateEnvironmentBlendModes.txt[]
   the required capacity.
 * pname:environmentBlendModeCountOutput is a pointer to the count of
   pname:environmentBlendModes written, or a pointer to the required capacity
-  in the case that pname:environmentBlendModeCapacityInput is 0.
+  in the case that pname:environmentBlendModeCapacityInput is insufficient.
 * pname:environmentBlendModes is a pointer to an array of
   elink:XrEnvironmentBlendMode values, but can: be code:NULL if
   pname:environmentBlendModeCapacityInput is 0.

--- a/specification/sources/chapters/semantic_paths.adoc
+++ b/specification/sources/chapters/semantic_paths.adoc
@@ -239,7 +239,7 @@ include::../../generated/api/protos/xrPathToString.txt[]
   a request to retrieve the required capacity.
 * pname:bufferCountOutput is a pointer to the count of characters written
   (including the terminating '\0'), or a pointer to the required capacity in
-  the case that pname:bufferCapacityInput is 0.
+  the case that pname:bufferCapacityInput is insufficient.
 * pname:buffer is a pointer to an application-allocated buffer that will be
   filled with the semantic path string.
   It can: be code:NULL if pname:bufferCapacityInput is 0.

--- a/specification/sources/chapters/spaces.adoc
+++ b/specification/sources/chapters/spaces.adoc
@@ -347,7 +347,7 @@ include::../../generated/api/protos/xrEnumerateReferenceSpaces.txt[]
   indicate a request to retrieve the required capacity.
 * pname:spaceCountOutput is a pointer to the count of spaces written, or a
   pointer to the required capacity in the case that pname:spaceCapacityInput
-  is 0.
+  is insufficient.
 * pname:spaces is a pointer to an application-allocated array that will be
   filled with the enumerant of each supported reference space.
   It can: be code:NULL if pname:spaceCapacityInput is 0.

--- a/specification/sources/chapters/view_configurations.adoc
+++ b/specification/sources/chapters/view_configurations.adoc
@@ -93,7 +93,7 @@ include::../../generated/api/protos/xrEnumerateViewConfigurations.txt[]
   required capacity.
 * pname:viewConfigurationsTypeCountOutput is a pointer to the count of
   pname:viewConfigurations written, or a pointer to the required capacity in
-  the case that pname:viewConfigurationsTypeCapacityInput is 0.
+  the case that pname:viewConfigurationsTypeCapacityInput is insufficient.
 * pname:viewConfigurationsTypes is a pointer to an array of
   elink:XrViewConfigurationType values, but can: be code:NULL if
   pname:viewConfigurationsTypeCapacityInput is 0.


### PR DESCRIPTION
Most array getters were specified to write out the number of elements
written if input capacity is nonzero, but cited the "Buffer Size
Parameters" section which specifies that the required capacity must be
written (and XR_ERROR_SIZE_INSUFFICIENT returned) if insufficient but
nonzero input capacity was specified. This standardizes on the latter
behavior.

Fixes #94.

This ended up touching a whole bunch of places. I found candidates for the fix by grepping for `buffer-size-parameters`.