### PR TITLE
Fix XrCreateVulkanInstanceCreateInfoKHR typo in khr_vulkan_enable2.adoc

### DIFF
--- a/changes/specification/pr.121.gh.OpenXR-Docs.md
+++ b/changes/specification/pr.121.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+`XR_KHR_vulkan_enable2`: Fix typo in parameter description of `xrCreateVulkanInstanceKHR`.

--- a/specification/sources/chapters/extensions/khr/khr_vulkan_enable2.adoc
+++ b/specification/sources/chapters/extensions/khr/khr_vulkan_enable2.adoc
@@ -136,7 +136,7 @@ include::../../../../generated/api/protos/xrCreateVulkanInstanceKHR.txt[]
 * pname:instance is an slink:XrInstance handle previously created with
   flink:xrCreateInstance.
 * pname:createInfo extensible input struct of type
-  sname:XrCreateVulkanInstanceCreateInfoKHR
+  sname:XrVulkanInstanceCreateInfoKHR
 * pname:vulkanInstance points to a sname:VkInstance handle to populate with
   the new Vulkan instance.
 * pname:vulkanResult points to a sname:VkResult to populate with the result

--- a/specification/sources/chapters/extensions/khr/khr_vulkan_enable2.adoc
+++ b/specification/sources/chapters/extensions/khr/khr_vulkan_enable2.adoc
@@ -136,7 +136,7 @@ include::../../../../generated/api/protos/xrCreateVulkanInstanceKHR.txt[]
 * pname:instance is an slink:XrInstance handle previously created with
   flink:xrCreateInstance.
 * pname:createInfo extensible input struct of type
-  sname:XrVulkanInstanceCreateInfoKHR
+  slink:XrVulkanInstanceCreateInfoKHR
 * pname:vulkanInstance points to a sname:VkInstance handle to populate with
   the new Vulkan instance.
 * pname:vulkanResult points to a sname:VkResult to populate with the result


### PR DESCRIPTION
I believe the `XrCreateVulkanInstanceCreateInfoKHR` type does not exist, and the `xrCreateVulkanInstanceKHR` function shows that the `XrVulkanInstanceCreateInfoKHR` is expected, so this seems to be a typo.