### PR TITLE
XR_EXT_composition_layer_frame_synthesis

### DIFF
--- a/changes/registry/mr.2200.gl.md
+++ b/changes/registry/mr.2200.gl.md
@@ -1,0 +1,4 @@
+---
+- issue.2200.gl
+---
+Add new `XR_EXT_composition_layer_frame_synthesis` multi-vendor extension.

--- a/changes/registry/mr.2200.gl.md
+++ b/changes/registry/mr.2200.gl.md
@@ -1,4 +1,4 @@
 ---
-- issue.2200.gl
+- pr.122.gh.OpenXR-Docs
 ---
 Add new `XR_EXT_composition_layer_frame_synthesis` multi-vendor extension.

--- a/changes/specification/mr.2200.gl.md
+++ b/changes/specification/mr.2200.gl.md
@@ -1,1 +1,4 @@
+---
+- pr.122.gh.OpenXR-Docs
+---
 Document new `XR_EXT_composition_layer_frame_synthesis` multi-vendor extension.

--- a/changes/specification/mr.2200.gl.md
+++ b/changes/specification/mr.2200.gl.md
@@ -1,0 +1,1 @@
+Document new `XR_EXT_composition_layer_frame_synthesis` multi-vendor extension.

--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -263,6 +263,9 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         <type bitvalues="XrDebugUtilsMessageSeverityFlagBitsEXT" category="bitmask">typedef <type>XrFlags64</type> <name>XrDebugUtilsMessageSeverityFlagsEXT</name>;</type>
         <type bitvalues="XrDebugUtilsMessageTypeFlagBitsEXT"     category="bitmask">typedef <type>XrFlags64</type> <name>XrDebugUtilsMessageTypeFlagsEXT</name>;</type>
 
+        <!-- Bitmask types for XR_EXT_composition_layer_frame_synthesis -->
+        <type bitvalues="XrCompositionLayerFrameSynthesisInfoFlagBitsEXT" category="bitmask">typedef <type>XrFlags64</type> <name>XrCompositionLayerFrameSynthesisInfoFlagsEXT</name>;</type>
+
         <!-- Bitmask types for XR_EXTX_overlay -->
         <type bitvalues="XrOverlayMainSessionFlagBitsEXTX"   category="bitmask">typedef <type>XrFlags64</type> <name>XrOverlayMainSessionFlagsEXTX</name>;</type>
         <type bitvalues="XrOverlaySessionCreateFlagBitsEXTX" category="bitmask">typedef <type>XrFlags64</type> <name>XrOverlaySessionCreateFlagsEXTX</name>;</type>
@@ -361,6 +364,9 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         <!-- flag bits for XR_EXT_debug_utils -->
         <type name="XrDebugUtilsMessageSeverityFlagBitsEXT" category="enum"/>
         <type name="XrDebugUtilsMessageTypeFlagBitsEXT" category="enum"/>
+
+        <!-- flag bits for XR_EXT_composition_layer_frame_synthesis -->
+        <type name="XrCompositionLayerFrameSynthesisInfoFlagBitsEXT" category="enum"/>
 
         <!-- flag bits for XR_EXTX_overlay -->
         <type name="XrOverlayMainSessionFlagBitsEXTX" category="enum"/>
@@ -1220,6 +1226,28 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
             <member values="XR_TYPE_EYE_GAZE_SAMPLE_TIME_EXT"><type>XrStructureType</type> <name>type</name></member>
             <member><type>void</type>*   <name>next</name></member>
             <member><type>XrTime</type>  <name>time</name></member>
+        </type>
+
+        <!-- XR_EXT_composition_layer_frame_synthesis -->
+        <type category="struct" name="XrCompositionLayerFrameSynthesisInfoEXT" structextends="XrCompositionLayerProjectionView">
+            <member values="XR_TYPE_COMPOSITION_LAYER_FRAME_SYNTHESIS_INFO_EXT"><type>XrStructureType</type> <name>type</name></member>
+            <member>const <type>void</type>*                                                  <name>next</name></member>
+            <member optional="true"><type>XrCompositionLayerFrameSynthesisInfoFlagsEXT</type> <name>layerFlags</name></member>
+            <member><type>XrSwapchainSubImage</type>                                          <name>motionVectorSubImage</name></member>
+            <member><type>XrVector4f</type>                                                   <name>motionVectorScale</name></member>
+            <member><type>XrVector4f</type>                                                   <name>motionVectorOffset</name></member>
+            <member><type>XrPosef</type>                                                      <name>appSpaceDeltaPose</name></member>
+            <member><type>XrSwapchainSubImage</type>                                          <name>depthSubImage</name></member>
+            <member><type>float</type>                                                        <name>minDepth</name></member>
+            <member><type>float</type>                                                        <name>maxDepth</name></member>
+            <member><type>float</type>                                                        <name>nearZ</name></member>
+            <member><type>float</type>                                                        <name>farZ</name></member>
+        </type>
+        <type category="struct" name="XrCompositionLayerFrameSynthesisConfigViewEXT" structextends="XrViewConfigurationView">
+            <member values="XR_TYPE_COMPOSITION_LAYER_FRAME_SYNTHESIS_CONFIG_VIEW_EXT"><type>XrStructureType</type> <name>type</name></member>
+            <member><type>void</type>*    <name>next</name></member>
+            <member><type>uint32_t</type> <name>recommendedMotionVectorImageRectWidth</name></member>
+            <member><type>uint32_t</type> <name>recommendedMotionVectorImageRectHeight</name></member>
         </type>
 
         <!-- types for XR_MSFT_spatial_anchor -->
@@ -2440,6 +2468,12 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
     <enums name="XrHandJointsMotionRangeEXT" type="enum">
         <enum value="1"   name="XR_HAND_JOINTS_MOTION_RANGE_UNOBSTRUCTED_EXT"/>
         <enum value="2"   name="XR_HAND_JOINTS_MOTION_RANGE_CONFORMING_TO_CONTROLLER_EXT"/>
+    </enums>
+
+    <!-- flags for XR_EXT_composition_layer_frame_synthesis -->
+    <enums name="XrCompositionLayerFrameSynthesisInfoFlagBitsEXT" type="bitmask">
+        <enum bitpos="0" name="XR_COMPOSITION_LAYER_FRAME_SYNTHESIS_INFO_USE_2D_MOTION_VECTOR_BIT_EXT"             comment="2D motion vector will be used"/>
+        <enum bitpos="1" name="XR_COMPOSITION_LAYER_FRAME_SYNTHESIS_INFO_ALLOW_HALF_REFRESH_RATE_THROTTLE_BIT_EXT" comment="Runtime might throttle the application's frame rate to half of display refresh rate"/>
     </enums>
 
     <!-- XR_MSFT_hand_tracking_mesh -->
@@ -6084,10 +6118,15 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         </require>
     </extension>
 
-    <extension name="XR_FB_extension_212" number="212" type="instance" supported="disabled">
+    <extension name="XR_EXT_composition_layer_frame_synthesis" number="212" type="instance" supported="openxr">
         <require>
-            <enum value="1"                               name="XR_FB_extension_212_SPEC_VERSION"/>
-            <enum value="&quot;XR_FB_extension_212&quot;" name="XR_FB_EXTENSION_212_EXTENSION_NAME"/>
+            <enum value="1"                                                    name="XR_EXT_composition_layer_frame_synthesis_SPEC_VERSION"/>
+            <enum value="&quot;XR_EXT_composition_layer_frame_synthesis&quot;" name="XR_EXT_COMPOSITION_LAYER_FRAME_SYNTHESIS_EXTENSION_NAME"/>
+
+            <enum offset="0" extends="XrStructureType"                         name="XR_TYPE_COMPOSITION_LAYER_FRAME_SYNTHESIS_INFO_EXT"/>
+            <enum offset="1" extends="XrStructureType"                         name="XR_TYPE_COMPOSITION_LAYER_FRAME_SYNTHESIS_CONFIG_VIEW_EXT"/>
+            <type name="XrCompositionLayerFrameSynthesisInfoEXT"/>
+            <type name="XrCompositionLayerFrameSynthesisConfigViewEXT"/>
         </require>
     </extension>
 

--- a/specification/sources/chapters/extensions/ext/ext_composition_layer_frame_synthesis.adoc
+++ b/specification/sources/chapters/extensions/ext/ext_composition_layer_frame_synthesis.adoc
@@ -1,0 +1,206 @@
+// Copyright (c) 2017-2022, The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::../meta/XR_EXT_composition_layer_frame_synthesis.adoc[]
+
+*Contributors*::
+    Jian Zhang, Meta Platforms +
+    Neel Bedekar, Meta Platforms +
+    Xiang Wei, Meta Platforms +
+    Rémi Arnaud, Varjo +
+    Paulo Gomes, Samsung Electronics +
+    Bryce Hutchings, Microsoft +
+    Ryan Pavlik, Collabora +
+
+
+:INCS-VAR: ../../../../generated
+
+*Overview*
+
+This extension provides support to enable composition layer frame synthesis
+ on applications.
+ By feeding application generated motion vector images and depth buffer
+ images, the runtime can do high quality frame extrapolation and
+ reprojection to synthesize a new frame, providing a smooth experience even
+ when the application is running below the FPS target.
+
+[NOTE]
+.Note
+====
+This extension is designed to be independent of
+<<XR_KHR_composition_layer_depth>>, and both may be enabled and used at the
+same time, for different purposes.
+The slink:XrCompositionLayerFrameSynthesisInfoEXT::pname:depthSubImage might
+use depth data dedicated for frame synthesis, and its resolution can be
+lower than slink:XrCompositionLayerDepthInfoKHR::pname:subImage.
+See slink:XrCompositionLayerFrameSynthesisConfigViewEXT for the suggested
+resolution of pname:depthSubImage.
+
+====
+
+*New Flag Types*
+
+[open,refpage='XrCompositionLayerFrameSynthesisInfoFlagsEXT',type='flags',desc='XrCompositionLayerFrameSynthesisInfoFlagsEXT']
+--
+include::{INCS-VAR}/api/flags/XrCompositionLayerFrameSynthesisInfoFlagsEXT.txt[]
+--
+
+[open,refpage='XrCompositionLayerFrameSynthesisInfoFlagBitsEXT',type='enums',desc='XrCompositionLayerFrameSynthesisInfoFlagBitsEXT',xrefs='XrCompositionLayerFrameSynthesisInfoFlagsEXT']
+--
+include::{INCS-VAR}/api/enums/XrCompositionLayerFrameSynthesisInfoFlagBitsEXT.txt[]
+
+--
+
+.Flag Descriptions
+****
+* ename:XR_COMPOSITION_LAYER_FRAME_SYNTHESIS_INFO_USE_2D_MOTION_VECTOR_BIT_EXT
+  indicates 2D motion vector data is used.
+* ename:XR_COMPOSITION_LAYER_FRAME_SYNTHESIS_INFO_ALLOW_HALF_REFRESH_RATE_THROTTLE_BIT_EXT
+  with this flag, the runtime might: throttle the application's frame rate
+  to half of the display refresh rate.
+****
+
+*New Enum Constants*
+
+elink:XrStructureType enumeration is extended with:
+
+* ename:XR_TYPE_COMPOSITION_LAYER_FRAME_SYNTHESIS_INFO_EXT
+* ename:XR_TYPE_COMPOSITION_LAYER_FRAME_SYNTHESIS_CONFIG_VIEW_EXT
+
+*New Structures*
+
+[open,refpage='XrCompositionLayerFrameSynthesisInfoEXT',type='structs',desc='Composition Layer Frame Synthesis structure',xrefs='XrCompositionLayerProjectionView XrCompositionLayerProjection XrCompositionLayerBaseHeader XrFrameEndInfo xrEndFrame']
+--
+
+When submitting motion vector buffers and depth buffers along with
+projection layers, add an slink:XrCompositionLayerFrameSynthesisInfoEXT
+structure to the slink:XrCompositionLayerProjectionView::pname:next chain,
+for each slink:XrCompositionLayerProjectionView structure in the given
+layer.
+
+The slink:XrCompositionLayerFrameSynthesisInfoEXT structure is defined as:
+include::{INCS-VAR}/api/structs/XrCompositionLayerFrameSynthesisInfoEXT.txt[]
+
+.Member Descriptions
+****
+* pname:type is the elink:XrStructureType of this structure.
+* pname:next is code:NULL or a pointer to the next structure in a structure
+  chain.
+* pname:layerFlags is a bitmask of
+  elink:XrCompositionLayerFrameSynthesisInfoFlagsEXT.
+* pname:motionVectorSubImage identifies the motion vector image
+  slink:XrSwapchainSubImage to be used for frame synthesis.
+* pname:motionVectorScale is an slink:XrVector4f which can be used to
+  modulate the motion vector sourced from slink:XrSwapchainSubImage.
+* pname:motionVectorOffset is an slink:XrVector4f which can be used to
+  offset the motion vector sourced from slink:XrSwapchainSubImage.
+* pname:appSpaceDeltaPose is the incremental application-applied transform,
+  if any, since the previous frame that affects the view.
+  When artificial locomotion (scripted movement, teleportation, etc.)
+  happens, the application may transform the whole
+  slink:XrCompositionLayerProjection::space from one application space pose
+  to another pose between frames.
+  The pose should be identity when there is no
+  slink:XrCompositionLayerProjection::space transformation in the
+  application.
+* pname:depthSubImage identifies the depth image slink:XrSwapchainSubImage
+  to be used for frame synthesis.
+* pname:minDepth and pname:maxDepth are the range of depth values the
+  pname:depthSwapchain could have, in the range of [eq]#[0.0,1.0]#.
+  This is akin to min and max values of OpenGL's fname:glDepthRange, but
+  with the requirement here that [eq]#maxDepth {geq} minDepth#.
+* pname:nearZ is the positive distance in meters of the pname:minDepth value
+  in the depth swapchain.
+  Applications may: use a pname:nearZ that is greater than pname:farZ to
+  indicate depth values are reversed.
+  pname:nearZ can be infinite.
+* pname:farZ is the positive distance in meters of the pname:maxDepth value
+  in the depth swapchain.
+  pname:farZ can be infinite.
+  The runtime must: return error ename:XR_ERROR_VALIDATION_FAILURE if
+  pname:nearZ == pname:farZ
+****
+
+The motion vector data can be derived from the pname:motionVectorSubImage's
+RGB channels, pname:motionVectorScale and pname:motionVectorOffset with the
+following formula: [eq]#motionVector = motionVectorSubImage~rgb~ *
+motionVectorScale~xyz~ {plus} motionVectorOffset~xyz~#, where
+[eq]#motionVectorSubImage~a~#, [eq]#motionVectorScale~w~# and
+[eq]#motionVectorOffset~w~# will be ignored.
+
+The motionVector represents movement since time
+slink:XrFrameEndInfo::displayTime for the previous frame until time
+slink:XrFrameEndInfo::displayTime for the current frame.
+The runtime can use this information to extrapolate the rendered frame into
+a future frame.
+The motionVector is expected to be defined in a [-1, -1, 0] to [1, 1, 1]
+style Normalized Device Coordinates (NDC) space, which is different from
+OpenGL's default NDC space definition.
+For example, given that a pixel's NDC in the previous frame is PrevNDC, and
+CurrNDC in current frame, and that there is no scale or offset, then the
+motion vector value is "[eq]#(CurrNDC - PrevNDC)~xyz~#".
+
+By default, 3D motion vector data is expected by the runtime, so
+[eq]#motionVectorSubImage~rgb~#, [eq]#motionVectorScale~xyz~# and
+[eq]#motionVectorOffset~xyz~# will be used.
+When
+ename:XR_COMPOSITION_LAYER_FRAME_SYNTHESIS_INFO_USE_2D_MOTION_VECTOR_BIT_EXT
+is enabled on pname:layerFlags, the runtime can accept 2D motion vector,
+which represents 2D pixel movement from the previous frame to the current
+frame, like: [eq]#motionVector = motionVectorSubImage~rg~ *
+motionVectorScale~xy~ {plus} motionVectorOffset~xy~#, where
+[eq]#motionVectorSubImage~ba~#, [eq]#motionVectorScale~zw~# and
+[eq]#motionVectorOffset~zw~# will be ignored.
+Using 2D motion vector data, as opposed to 3D, might limit the potential
+quality of the frames synthesized.
+
+[NOTE]
+.Note
+====
+There are many different ways to generate pname:motionVectorSubImage and
+pname:depthSubImage.
+For example, the application may render them in a lower resolution dedicated
+motion vector pass (see slink:XrCompositionLayerFrameSynthesisConfigViewEXT
+for recommended resolution ), or render them in the main view pass with MRT
+(Multiple Render Targets).
+It is up to the application to decide the specific approach.
+Signed 16 bit float per pixel channel formats are recommended for
+pname:motionVectorSubImage.
+====
+
+include::{INCS-VAR}/validity/structs/XrCompositionLayerFrameSynthesisInfoEXT.txt[]
+--
+
+[open,refpage='XrCompositionLayerFrameSynthesisConfigViewEXT',type='structs',desc='Composition Layer Frame Synthesis structure',xrefs='XrViewConfigurationView']
+--
+When this extension is enabled, an application can: pass in an
+slink:XrCompositionLayerFrameSynthesisConfigViewEXT structure in the
+slink:XrViewConfigurationView::pname:next chain when calling
+flink:xrEnumerateViewConfigurationViews to acquire information about the
+recommended motion vector buffer resolution.
+The slink:XrCompositionLayerFrameSynthesisConfigViewEXT structure is defined
+as:
+
+include::{INCS-VAR}/api/structs/XrCompositionLayerFrameSynthesisConfigViewEXT.txt[]
+
+.Member Descriptions
+****
+* pname:type is the elink:XrStructureType of this structure.
+* pname:next is code:NULL or a pointer to the next structure in a structure
+  chain.
+* pname:recommendedMotionVectorImageRectWidth: recommended motion vector and
+  depth image width.
+* pname:recommendedMotionVectorImageRectHeight: recommended motion vector
+  and depth image height.
+****
+include::{INCS-VAR}/validity/structs/XrCompositionLayerFrameSynthesisConfigViewEXT.txt[]
+--
+
+*Issues*
+
+*Version History*
+
+* Revision 1, 2022-01-31 (Jian Zhang)
+** Initial extension description, converted from fb_space_warp
+** Collabrrating with contributors to refine the extension interfaces.


### PR DESCRIPTION
This has been drafted by multiple vendors in the working group, who have agreed to publish it in a pull request as a draft, to gather feedback before integrating it.

Here are **draft** (unofficial) versions of the HTML spec and the header file with this extension added:

- HTML spec (zipped): [openxr.html.zip](https://github.com/KhronosGroup/OpenXR-Docs/files/8533524/openxr.html.zip) 
- openxr.h header (renamed to pass GitHub's file type filter): [openxr.h.txt](https://github.com/KhronosGroup/OpenXR-Docs/files/8533526/openxr.h.txt)
 