### PR TITLE
Add vendor ID for Matthieu Bucchianeri.

### DIFF
--- a/changes/registry/pr143.gh.OpenXR-Docs.md
+++ b/changes/registry/pr143.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+Register author ID for Matthieu Bucchianeri.

--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -46,6 +46,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         <tag name="KHR"        author="Khronos"                     contact="Brent Insko @insko"/>
         <tag name="LUNARG"     author="LunarG"                      contact="Brad Grantham @bradgrantham-lunarg"/>
         <tag name="LIV"        author="LIV"                         contact="Arthur Brainville @Ybalrid, Steffan Donal @liv_ruu"/>
+        <tag name="MBUCCHIA"   author="Matthieu Bucchianeri"        contact="Matthieu Bucchianeri @mbucchia"/>
         <tag name="META"       author="Meta Platforms"              contact="Cass Everitt @casseveritt, Jonathan Wright @Nelno"/>
         <tag name="ML"         author="Magic Leap"                  contact="Jey Michaelraj @jeymichael"/>
         <tag name="MND"        author="Monado Project"              contact="Jakob Bornecrantz @wallbraker, Ryan Pavlik @rpavlik"/>


### PR DESCRIPTION
Add vendor ID `MBUCCHIA` to use for OpenXR API layers developed by Matthieu Bucchianeri.

Mimic'ing process followed by fellow developer here: https://github.com/KhronosGroup/OpenXR-SDK-Source/pull/319.
