### PR TITLE
registry: spec: Update XR_MNDX_egl_enable's version to 2

### DIFF
--- a/changes/registry/pr.159.gh.OpenXR-Docs.md
+++ b/changes/registry/pr.159.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+`XR_MNDX_egl_enable`: Update version to 2 to reflect function pointer type change.

--- a/changes/specification/pr.159.gh.OpenXR-Docs.md
+++ b/changes/specification/pr.159.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+`XR_MNDX_egl_enable`: Update revision info and version to 2 to reflect function pointer type change.

--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -7492,7 +7492,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
 
     <extension name="XR_MNDX_egl_enable" number="49" type="instance" provisional="true" protect="XR_USE_PLATFORM_EGL" supported="openxr">
         <require>
-            <enum value="1"                              name="XR_MNDX_egl_enable_SPEC_VERSION"/>
+            <enum value="2"                              name="XR_MNDX_egl_enable_SPEC_VERSION"/>
             <enum value="&quot;XR_MNDX_egl_enable&quot;" name="XR_MNDX_EGL_ENABLE_EXTENSION_NAME"/>
             <enum offset="4" extends="XrStructureType"   name="XR_TYPE_GRAPHICS_BINDING_EGL_MNDX"/>
             <type name="XrGraphicsBindingEGLMNDX"/>

--- a/specification/sources/chapters/extensions/mndx/mndx_egl_enable.adoc
+++ b/specification/sources/chapters/extensions/mndx/mndx_egl_enable.adoc
@@ -5,7 +5,7 @@
 include::{generated}/meta/XR_MNDX_egl_enable.adoc[]
 
 *Last Modified Date*::
-    2022-11-03
+    2023-12-02
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -88,3 +88,8 @@ https://registry.khronos.org/EGL/sdk/docs/man/html/eglGetProcAddress.xhtml
 
 * Revision 1, 2020-05-20 (Jakob Bornecrantz)
 ** Initial draft
+
+* Revision 2, 2023-12-02
+** Use `PFN_xrEglGetProcAddressMNDX` to replace `PFNEGLGETPROCADDRESSPROC`
+   (for `eglGetProcAddress`).
+   Note this does change function pointer attributes on some platforms.


### PR DESCRIPTION
From 1.0.29, XR_MNDX_egl_enable changed the type of getProcAddress from PFNEGLGETPROCADDRESSPROC to new added PFN_xrEglGetProcAddressMNDX. When I tried to bump to this version for Monado, it caused compiling error for Android NDK armeabi-v7a because new function type has extra attribute definition. From this experience, the 1.0.29's change changed the extension APIs, and we might need to bump the version of this extension to 2 to let Runtime and apps know it.