### PR TITLE
Register author ID DXR for The DisplayXR Project

### DIFF
--- a/changes/registry/pr.199.gh.OpenXR-Docs.md
+++ b/changes/registry/pr.199.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+Addition: Register author tag for The DisplayXR Project.

--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -37,6 +37,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         <tag name="COLLABORA"  author="Collabora"             contact="Rylie Pavlik @rpavlik"/>
         <tag name="DANWILLM"   author="Daniel Willmott"       contact="Daniel Willmott @danwillm"/>
         <tag name="DEEPMIRROR" author="Deep Mirror"           contact="Yuhui Lun @lyh-dm"/>
+        <tag name="DXR"        author="The DisplayXR Project" contact="David Fattal @dfattal"/>
         <tag name="EPIC"       author="Epic"                  contact="Nick Whiting @whitingn"/>
         <tag name="EXT"        author="Multivendor"           contact="Rylie Pavlik @rpavlik"/>
         <tag name="FB"         author="Facebook"              contact="Cass Everitt @casseveritt, Jonathan Wright @Nelno"/>


### PR DESCRIPTION
Reserving the author ID `DXR` for The DisplayXR Project — an open-source, vendor-neutral OpenXR runtime for glasses-free 3D displays (https://github.com/DisplayXR/displayxr-runtime).

We ship several runtime extensions (display info, display zones, window bindings) that we intend to publish as `XR_DXR_*` while incubating, with the goal of proposing multi-vendor EXT versions to the working group over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)