### PR TITLE
Fix incorrect struct initialization in khr_locate_spaces sample code

### DIFF
--- a/changes/specification/pr.200.gh.OpenXR-Docs.md
+++ b/changes/specification/pr.200.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+`XR_KHR_locate_spaces`: Fix sample code that initialized `XrSpaceLocationsKHR` with the wrong structure type, `XR_TYPE_SPACES_LOCATE_INFO_KHR` instead of `XR_TYPE_SPACE_LOCATIONS_KHR`.

--- a/specification/sources/chapters/extensions/khr/khr_locate_spaces.adoc
+++ b/specification/sources/chapters/extensions/khr/khr_locate_spaces.adoc
@@ -5,7 +5,7 @@
 include::{generated}/meta/XR_KHR_locate_spaces.adoc[]
 
 *Last Modified Date*::
-    2024-01-19
+    2026-07-10
 
 *IP Status*::
     No known IP claims.
@@ -267,7 +267,7 @@ while (1) {
     };
 
     XrSpaceLocationsKHR locations {
-        .type = XR_TYPE_SPACES_LOCATE_INFO_KHR,
+        .type = XR_TYPE_SPACE_LOCATIONS_KHR,
         .next = &velocities,
         .locationCount = static_cast<uint32_t>(locationBuffer.size()),
         .locations = locationBuffer.data(),


### PR DESCRIPTION
XrSpaceLocationsKHR was initialized with XR_TYPE_SPACES_LOCATE_INFO_KHR (the locate-info struct's type token) instead of
XR_TYPE_SPACE_LOCATIONS_KHR, so the sample as written is rejected by a conformant runtime. The core-spec version of the same sample in spaces.adoc already uses the correct token.

Also update the extension's last modified date.