### PR TITLE
Register DXR author ID for The DisplayXR Project

### DIFF
--- a/changes/registry/pr.201.gh.OpenXR-Docs.md
+++ b/changes/registry/pr.201.gh.OpenXR-Docs.md
@@ -1,0 +1,1 @@
+Chore: Register `DXR` author ID for The DisplayXR Project.

--- a/specification/registry/xr.xml
+++ b/specification/registry/xr.xml
@@ -37,6 +37,7 @@ maintained in the default branch of the Khronos OpenXR GitHub project.
         <tag name="COLLABORA"  author="Collabora"             contact="Rylie Pavlik @rpavlik"/>
         <tag name="DANWILLM"   author="Daniel Willmott"       contact="Daniel Willmott @danwillm"/>
         <tag name="DEEPMIRROR" author="Deep Mirror"           contact="Yuhui Lun @lyh-dm"/>
+        <tag name="DXR"        author="The DisplayXR Project" contact="David Fattal @dfattal"/>
         <tag name="EPIC"       author="Epic"                  contact="Nick Whiting @whitingn"/>
         <tag name="EXT"        author="Multivendor"           contact="Rylie Pavlik @rpavlik"/>
         <tag name="FB"         author="Facebook"              contact="Cass Everitt @casseveritt, Jonathan Wright @Nelno"/>


### PR DESCRIPTION
Resubmission of #199, per the review feedback there: reserving the author ID `DXR` for The DisplayXR Project — an open-source, vendor-neutral OpenXR runtime for glasses-free 3D displays (https://github.com/DisplayXR/displayxr-runtime).

Compared to #199: a fresh single commit with no software co-author trailer, and the changelog fragment reformatted as a `Chore:` entry to match past registry changelogs.

Thanks for the quick turnaround on the original, and apologies for the extra round-trip.